### PR TITLE
Allow "-ex" to work without "-in"

### DIFF
--- a/src/dox/Processor.hx
+++ b/src/dox/Processor.hx
@@ -220,6 +220,6 @@ class Processor {
 		for (filter in config.pathFilters) {
 			if (filter.r.match(path)) return !filter.isIncludeFilter;
 		}
-		return !config.pathFilters.isEmpty();
+		return !config.pathFilters.exists(function (f) return f.isIncludeFilter);
 	}
 }


### PR DESCRIPTION
Return true even if pathFilters exist, as long as there are none of them are include filters.

Made the change using Github's interface.  Have not tested it...
