### PR TITLE
initial documentation

### DIFF
--- a/src/dox/Generator.hx
+++ b/src/dox/Generator.hx
@@ -46,7 +46,6 @@ class Generator {
 			case TPackage(name, full, subs):
 				if (name.charAt(0) == "_") return;
 				api.currentPageName = "package " + name;
-				api.currentFullName = "package " + full;
 				api.config.setRootPath(full == '' ? full : full + ".pack");
 				var s = tplPackage.execute({
 					api: api,
@@ -59,7 +58,6 @@ class Generator {
 				subs.iter(generateTree);
 			case TClassdecl(c):
 				api.currentPageName = api.getPathName(c.path);
-				api.currentFullName = c.path;
 				api.config.setRootPath(c.path);
 				var s = tplClass.execute({
 					api: api,
@@ -71,7 +69,6 @@ class Generator {
 				api.infos.numGeneratedTypes++;
 			case TEnumdecl(e):
 				api.currentPageName = api.getPathName(e.path);
-				api.currentFullName = e.path;
 				api.config.setRootPath(e.path);
 				var s = tplEnum.execute({
 					api: api,
@@ -81,7 +78,6 @@ class Generator {
 				api.infos.numGeneratedTypes++;
 			case TTypedecl(t):
 				api.currentPageName = api.getPathName(t.path);
-				api.currentFullName = t.path;
 				api.config.setRootPath(t.path);
 				var s = tplTypedef.execute({
 					api: api,
@@ -91,7 +87,6 @@ class Generator {
 				api.infos.numGeneratedTypes++;
 			case TAbstractdecl(a):
 				api.currentPageName = api.getPathName(a.path);
-				api.currentFullName = a.path;
 				api.config.setRootPath(a.path);
 				var s = tplAbstract.execute({
 					api: api,

--- a/src/dox/Infos.hx
+++ b/src/dox/Infos.hx
@@ -2,12 +2,36 @@ package dox;
 import haxe.rtti.CType;
 using Lambda;
 
+/**
+	Infos is a collection of information collected by Dox during processing.
+	
+	An instance can be accessed as `api.infos` in templates.
+**/
 class Infos {
 	
+	/**
+		A map of dot-paths to their corresponding `TypeInfos` objects.
+	**/
 	public var typeMap:Map<String, TypeInfos>;
+	
+	/**
+		A map of dot-path classes to their sub classes.
+	**/
 	public var subClasses:Map<String, Array<TypeInfos>>;
+	
+	/**
+		A map of dot-path interfaces to their implementors.
+	**/
 	public var implementors:Map<String, Array<TypeInfos>>;
+	
+	/**
+		The number of generated types.
+	**/
 	public var numGeneratedTypes(default, set):Int;
+	
+	/**
+		The number of generated packages.
+	**/
 	public var numGeneratedPackages:Int;
 	
 	var packages:Map<String, Map<String, String>>;
@@ -31,7 +55,17 @@ class Infos {
 		Reflect.setField(this, "numGeneratedTypes", 0);
 	}
 	
-	public function resolveType(path:String, type:String)
+	/**
+		Checks if `meta` contains a `@:dox` metadata.
+		
+		If `parameterName` is not null, also checks if `@:doc` has an argument
+		equal to `parameterName`.
+	**/
+	static public function hasDoxMetadata(meta:MetaData, ?parameterName:String):Bool {
+		return meta.exists(function(m) return m.name == ":dox" && parameterName == null || m.params.has(parameterName));
+	}
+
+	function resolveType(path:String, type:String)
 	{
 		// direct match
 		if (typeMap.exists(type)) return type;
@@ -55,7 +89,8 @@ class Infos {
 		return null;
 	}
 
-	public function addType(path:String, typeInfos:TypeInfos) {
+	@:allow(dox.Processor)
+	function addType(path:String, typeInfos:TypeInfos) {
 		var parts = path.split('.');
 		var name = parts.pop();
 		var pack = parts.join('.');
@@ -68,9 +103,5 @@ class Infos {
 		typeMap.set(path, typeInfos);
 		numProcessedTypes++;
 		if (numProcessedTypes & 16 == 0) Sys.print(".");
-	}
-	
-	public function hasDoxMetadata(meta:MetaData, ?parameterName:String) {
-		return meta.exists(function(m) return m.name == ":dox" && parameterName == null || m.params.has(parameterName));
 	}
 }

--- a/src/dox/MarkdownHandler.hx
+++ b/src/dox/MarkdownHandler.hx
@@ -30,6 +30,7 @@ class MarkdownHandler {
 		return Markdown.renderHtml(blocks);
 	}
 
+	@:access(dox.Infos.resolveType)
 	function processCode(path:String, source:String) {
 		source = StringTools.htmlEscape(source);
 

--- a/src/dox/Processor.hx
+++ b/src/dox/Processor.hx
@@ -86,7 +86,7 @@ class Processor {
 	
 	function filterFields(fields:List<ClassField>) {
 		return fields.filter(function(cf) {
-			return cf.isPublic && !infos.hasDoxMetadata(cf.meta, "hide") || infos.hasDoxMetadata(cf.meta, "show");
+			return cf.isPublic && !Infos.hasDoxMetadata(cf.meta, "hide") || Infos.hasDoxMetadata(cf.meta, "show");
 		});
 	}
 	


### PR DESCRIPTION
Also removes `public` from a few internal fields and uses ACL instead.

Please check the two `@todo`s before/after merging, I'm not quite sure how/why these work. 
