### PR TITLE
Don't match multiline indent styles

### DIFF
--- a/src/dox/Processor.hx
+++ b/src/dox/Processor.hx
@@ -210,7 +210,7 @@ class Processor {
 		while (doc.charAt(doc.length - 1) == '*') doc = doc.substr(0, doc.length - 1);
 		
 		// detect doc comment tyle/indent
-		var ereg = ~/^( \* |\t\* |\t \* |\t\t| +\* )/m;
+		var ereg = ~/^( \* |\t\* |\t \* |\t\t| +\* )/;
 		var matched = ereg.match(doc);
 
 		// special case for single tab indent because my regex isn't clever enough


### PR DESCRIPTION
This regex currently matches two tabs later in the doc string, like a code sample. We really only want to check the first line.
