### PR TITLE
Don't allow markdown parsing errors to stop doc generation

### DIFF
--- a/src/dox/MarkdownHandler.hx
+++ b/src/dox/MarkdownHandler.hx
@@ -30,6 +30,7 @@ class MarkdownHandler {
 			var blocks = document.parseLines(lines);
 			return Markdown.renderHtml(blocks);
 		} catch(err: Dynamic) {
+			trace("Parsing warning: " + err);
 			return markdown;
 		}
 	}


### PR DESCRIPTION
I think this solves #58.
It doesn't make the doc comment ASCII art perfect, but at least it makes Dox not fail due to Markdown parsing error.
