### PR TITLE
Added missing -lib hxparse to run.hxml

### DIFF
--- a/run.hxml
+++ b/run.hxml
@@ -1,4 +1,5 @@
 -lib hxtemplo
+-lib hxparse
 -lib hxargs
 -lib markdown
 -cp src


### PR DESCRIPTION
When hxtemplo is installed by `haxelib git`, which is told by dox's README, haxelib will not know hxparse is hxtemplo's dependency so `-lib hxparse` is needed.

This leads to the haxe unit test failing.
