### PR TITLE
params/throws as tables

### DIFF
--- a/themes/default/resources/styles.css
+++ b/themes/default/resources/styles.css
@@ -213,6 +213,14 @@ h6 {
   padding-left:20px;
 }
 
+table.params {
+  border-left: 5px solid #eeeeee;
+  margin-left: 20px;
+}
+table.params th {
+  background:#fcfcfc;
+}
+
 .doc-main {
   margin-bottom: 40px;
 }

--- a/themes/default/templates/doc.mtt
+++ b/themes/default/templates/doc.mtt
@@ -8,11 +8,22 @@
 
 ::if info.params.length > 0::
 	<p class="javadoc">Parameters:</p>
+		<table class="table table-bordered params">
 	::foreach param info.params::
+			<tr><th width="25%"><code>::param.value::</code></th><td>::raw param.doc::</td></tr>
+	::end::
+	</table>
+::end::
+
+::if info.throws.length > 0::
+	<p class="javadoc">Throws:</p>
+		<table class="table table-bordered params">
+	::foreach throws info.throws::
 		<div class="indent inline-content">
-			<code>::param.value::</code> ::raw param.doc::
+			<tr><th width="25%"><code>::throws.value::</code></th><td>::raw throws.doc::</td></tr>
 		</div>
 	::end::
+	</table>
 ::end::
 
 ::if info.returns != null::
@@ -20,15 +31,6 @@
 	<div class="indent inline-content">
 		::raw info.returns.doc::
 	</div>
-::end::
-
-::if info.throws.length > 0::
-	<p class="javadoc">Throws:</p>
-	::foreach throws info.throws::
-		<div class="indent inline-content">
-			<code>::throws.value::</code> ::raw throws.doc::
-		</div>
-	::end::
 ::end::
 
 ::if info.since != null::


### PR DESCRIPTION
I think putting this in tables makes it more readable, especially if `code` is used in the description.

old:
![image](https://cloud.githubusercontent.com/assets/576184/14796342/2241c49e-0b2d-11e6-8e4a-f0806981d5a3.png)

new:

![image](https://cloud.githubusercontent.com/assets/576184/14796360/3498e1fe-0b2d-11e6-8024-22f4f3e1b675.png)
