### PR TITLE
meta description

### DIFF
--- a/themes/default/templates/main.mtt
+++ b/themes/default/templates/main.mtt
@@ -28,6 +28,10 @@
 	<script type="text/javascript" src="::api.config.rootPath::/index.js"></script>
 	<link rel="icon" href="::api.config.rootPath::/favicon.ico" type="image/x-icon"></link>
 	<title>::api.currentPageName::::if api.config.pageTitle !=null:: - ::api.config.pageTitle::::end::</title>
+
+	::set description = api.getShortDesc(type)::
+	::set description = description.substr(3, description.length-7)::
+	<meta name="description" ::cond type.doc!=null && description.length>0:: content="::description::"/>
 </head>
 <body>
 	<nav class="section nav dark">


### PR DESCRIPTION
Use the short description. I use `substr` to leave out the `<p>` tag. 
No description meta tag is added when there is nothing to display.

I hope this addition will improve this:

![image](https://cloud.githubusercontent.com/assets/576184/14824190/5fd80d06-0bd5-11e6-9fbc-57b39c8a9411.png)
