### PR TITLE
Make default theme easier to customise

### DIFF
--- a/src/dox/Dox.hx
+++ b/src/dox/Dox.hx
@@ -69,6 +69,11 @@ class Dox {
 					if (theme.parentTheme != null) {
 						setTheme(theme.parentTheme);
 					}
+					// set theme defines
+					for (varName in Reflect.fields(theme.defines)) {
+						var varValue = Reflect.field(theme.defines, varName);
+						cfg.defines.set(varName, varValue);
+					}
 					cfg.resourcePaths.push(Path.join([path, "resources"]));
 					loadTemplates(cfg, Path.join([path, "templates"]));
 					return theme;

--- a/src/dox/Theme.hx
+++ b/src/dox/Theme.hx
@@ -4,5 +4,6 @@ typedef Theme = {
 	name: String,
 	author: String,
 	?parentTheme: String,
-	headerIncludes: Array<String>
+	headerIncludes: Array<String>,
+	?defines: Dynamic
 }

--- a/themes/default/config.json
+++ b/themes/default/config.json
@@ -1,4 +1,8 @@
 {
   "name": "Default Haxe Theme",
-  "author": "Haxe Foundation"
+  "author": "Haxe Foundation",
+  "defines": {
+    "collapsedClass": "fa-arrow-circle-o-right",
+    "expandedClass": "fa-arrow-circle-o-down" 
+  }
 }

--- a/themes/default/resources/index.js
+++ b/themes/default/resources/index.js
@@ -1,3 +1,6 @@
+var collapsedClass = "fa-arrow-circle-o-right";
+var expandedClass = "fa-arrow-circle-o-down";
+
 function createCookie(name, value, days) {
 	localStorage.setItem(name, value);
 }
@@ -10,9 +13,9 @@ function toggleInherited(el) {
 	var toggle = $(el).closest(".toggle");
 	toggle.toggleClass("toggle-on");
 	if (toggle.hasClass("toggle-on")) {
-		$("i", toggle).removeClass("fa-arrow-circle-o-right").addClass("fa-arrow-circle-o-down");
+		$("i", toggle).removeClass(collapsedClass).addClass(expandedClass);
 	} else {
-		$("i", toggle).addClass("fa-arrow-circle-o-right").removeClass("fa-arrow-circle-o-down");
+		$("i", toggle).addClass(collapsedClass).removeClass(expandedClass);
 	}
     return false;
 }
@@ -22,9 +25,9 @@ function toggleCollapsed(el) {
 	toggle.toggleClass("expanded");
 
 	if (toggle.hasClass("expanded")) {
-		$(toggle).find("i").first().removeClass("fa-arrow-circle-o-right").addClass("fa-arrow-circle-o-down");
+		$(toggle).find("i").first().removeClass(collapsedClass).addClass(expandedClass);
 	} else {
-		$(toggle).find("i").first().addClass("fa-arrow-circle-o-right").removeClass("fa-arrow-circle-o-down");
+		$(toggle).find("i").first().addClass(collapsedClass).removeClass(expandedClass);
 	}
 	updateTreeState();
     return false;
@@ -86,7 +89,7 @@ $(document).ready(function(){
 	var treeState = readCookie("treeState");
 
 	$("#nav .expando").each(function(i, e){
-		$("i", e).first().addClass("fa-arrow-circle-o-right").removeClass("fa-arrow-circle-o-down");
+		$("i", e).first().addClass(collapsedClass).removeClass(expandedClass);
 	});
 
 	$(".treeLink").each(function() {
@@ -99,7 +102,7 @@ $(document).ready(function(){
 		$("#nav .expando").each(function(i, e){
 			if (states[i]) {
 				$(e).addClass("expanded");
-				$("i", e).first().removeClass("fa-arrow-circle-o-right").addClass("fa-arrow-circle-o-down");
+				$("i", e).first().removeClass(collapsedClass).addClass(expandedClass);
 			}
 		});
 	}
@@ -130,9 +133,9 @@ $(document).ready(function(){
 	$("a.expand-button").click(function (e) {
 		var container = $(this).parent().next();
 		container.toggle();
-		$("i", this).removeClass("fa-arrow-circle-o-down")
-				.removeClass("fa-arrow-circle-o-right")
-				.addClass(container.is(":visible") ? "fa-arrow-circle-o-down" : "fa-arrow-circle-o-right");
+		$("i", this).removeClass(expandedClass)
+				.removeClass(collapsedClass)
+				.addClass(container.is(":visible") ? expandedClass : collapsedClass);
 		return false;
 	});
 

--- a/themes/default/resources/styles-ext.css
+++ b/themes/default/resources/styles-ext.css
@@ -1,0 +1,3 @@
+/*
+Placeholder css file so themes can extend default and not have to duplicate all the css
+*/

--- a/themes/default/templates/footer.mtt
+++ b/themes/default/templates/footer.mtt
@@ -1,0 +1,11 @@
+<footer class="section dark site-footer">
+	<div class="container">
+		<div class="copyright">
+			<p ::cond api.isDefined("version")::>This documentation is generated for version ::api.getValue('version')::</p>
+			<p>&copy;2015&nbsp;
+			<a href="http://haxe.org/foundation/" title="Haxe Foundation Website" class="hf-link">Haxe Foundation</a> |&nbsp;
+			<a href="https://github.com/HaxeFoundation/haxe" title="Haxe on Github">Contribute to Haxe</a>
+			</p>
+		</div>
+	</div>
+</footer>

--- a/themes/default/templates/header.mtt
+++ b/themes/default/templates/header.mtt
@@ -1,0 +1,47 @@
+<nav class="section nav dark">
+	<div class="navbar navbar-fixed-top navbar-inverse">
+		<div class="navbar-inner">
+			<button class="btn btn-navbar" data-target=".nav-collapse" data-toggle="collapse" type="button"><span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span></button> <a class="brand haxe-logo" href="http://haxe.org/"><img alt="Haxe" height="21" onerror="this.src='http://haxe.org/img/haxe-logo-horizontal-on-dark.png'" src="http://haxe.org/img/haxe-logo-horizontal-on-dark.svg" width="107" /></a>
+			
+			<a class="brand sub lib" href="/">API</a>
+
+			<div class="nav-collapse collapse">
+				<ul class="nav">
+					<!-- required submenu  on every subsite, put class="active" on   -->
+					<li class="dropdown">
+						<a class="dropdown-toggle" data-toggle="dropdown" href="/documentation/">Learn Haxe <b class="caret"></b></a>
+						<ul class="dropdown-menu">
+							<li><a href="http://haxe.org/documentation/">Introduction</a></li>
+							<li class="divider"></li>
+							<li><a href="http://haxe.org/manual/">Manual</a></li>
+							<li class="active"><a href="http://api.haxe.org">API Documentation</a></li>
+							<li class="divider"></li>
+							<li><a href="http://try.haxe.org">Try Haxe</a></li>
+							<li><a href="http://lib.haxe.org">Haxelib</a></li>
+							<li><a href="http://code.haxe.org">Code Cookbook</a></li>
+						</ul>
+					</li>
+					<li class=" dropdown">
+						<a class="dropdown-toggle" data-toggle="dropdown" href="#">Connect <b class="caret"></b></a>
+						<ul class="dropdown-menu">
+							<li><a href="https://github.com/HaxeFoundation"><i class="fa fa-github"></i> Github</a></li>
+							<li><a href="https://github.com/HaxeFoundation/haxe/issues"><i class="fa fa-github"></i> Bug reports</a></li>
+							<li><a href="http://stackoverflow.com/questions/tagged/haxe"><i class="fa fa-stack-exchange"></i> Stack Overflow</a></li>
+							<li><a href="http://groups.google.com/group/haxelang?hl=en"><i class="fa fa-envelope-o"></i> Google Groups</a></li>
+							<li><a href="http://webchat.freenode.net/?channels=haxe"><i class="fa fa-comments-o"></i> IRC</a></li>
+							<li><a href="http://haxe.org/blog"><i class="fa fa-rss"></i> Blog</a></li>
+							<li class="divider"></li>
+							<li><a href="https://plus.google.com/communities/103302587329918132234"><i class="fa fa-google-plus"></i> Google+</a></li>
+							<li><a href="https://www.facebook.com/haxe.org/"><i class="fa fa-facebook"></i> Facebook</a></li>
+							<li><a href="https://twitter.com/search?q=%23haxe"><i class="fa fa-twitter"></i> #haxe</a></li>
+							<li><a href="https://twitter.com/haxelang"><i class="fa fa-twitter"></i> @haxelang</a></li>
+							<li><a href="https://twitter.com/haxe_org"><i class="fa fa-twitter"></i> @haxe_org</a></li>
+							<li class="divider"></li>
+							<li><a href="http://haxe.org/foundation/contact.html">Contact</a></li>
+						</ul>
+					</li>
+				</ul>
+			</div>
+		</div>
+	</div>
+</nav>

--- a/themes/default/templates/macros.mtt
+++ b/themes/default/templates/macros.mtt
@@ -90,7 +90,7 @@
 	::if fieldInfo.modifiers.isInline::
 		<span class="label">inline</span> 
 	::end::
-	
+
 	::switch fieldInfo.kind::
 		::switch field.set::
 		::case 1::
@@ -100,6 +100,8 @@
 		::case 1::
 			<span class="label">write only</span>
 		::end::
+
+	::use"additional_field_labels.mtt"::::end::
 
 	<a href="::api.pathToUrl(type.path)::#::field.name::"><span class="identifier">::field.name::</span></a>:$$printLinkedType(::field.type::)$$printInitExpr(::field.expr::)
 

--- a/themes/default/templates/macros.mtt
+++ b/themes/default/templates/macros.mtt
@@ -234,7 +234,7 @@
 		<div class="fields" ::cond hasFields::>
 			::set fields=inheritedFields.fields::
 			::foreach cl inheritedFields.types::
-				<h4 ::cond fields.get(cl).length>0::><a href="#" class="expand-button"><i class="fa fa-arrow-circle-o-right"></i></a> Defined by $$printLinkedPath(::cl.path::,::null::)</h4>
+				<h4 ::cond fields.get(cl).length>0::><a href="#" class="expand-button"><i class="fa ::api.config.defines.get("collapsedClass")::"></i></a> Defined by $$printLinkedPath(::cl.path::,::null::)</h4>
 				<div style="display:none">
 				::foreach field fields.get(cl)::
 					::set isStatic = false::
@@ -249,7 +249,7 @@
 		<div class="fields" ::cond hasMethods::>
 			::set fields=inheritedFields.methods::
 			::foreach cl inheritedFields.types::
-				<h4 ::cond fields.get(cl).length>0::><a href="#" class="expand-button"><i class="fa fa-arrow-circle-o-right"></i></a> Defined by $$printLinkedPath(::cl.path::,::null::)</h4>
+				<h4 ::cond fields.get(cl).length>0::><a href="#" class="expand-button"><i class="fa ::api.config.defines.get("collapsedClass")::"></i></a> Defined by $$printLinkedPath(::cl.path::,::null::)</h4>
 				<div style="display:none">
 				::foreach field fields.get(cl)::
 				::set isStatic = false::

--- a/themes/default/templates/main.mtt
+++ b/themes/default/templates/main.mtt
@@ -33,6 +33,12 @@
 	::set description = api.getShortDesc(type)::
 	::set description = description.substr(3, description.length-7)::
 	<meta name="description" ::cond type.doc!=null && description.length>0:: content="::description::"/>
+	
+	<script>
+	::foreach key api.config.defines.keys()::
+		var ::key:: = "::api.config.defines.get(key)::";
+	::end::
+	</script>
 </head>
 <body>
 

--- a/themes/default/templates/main.mtt
+++ b/themes/default/templates/main.mtt
@@ -14,6 +14,7 @@
 	<script src="::api.config.rootPath::bootstrap/js/bootstrap.min.js"></script>
 	<script src="::api.config.rootPath::bootstrap/js/bootstrap-select.min.js"></script>
 	<link href="::api.config.rootPath::styles.css" rel="stylesheet" />
+	<link href="::api.config.rootPath::styles-ext.css" rel="stylesheet" />
 	<link href="::api.config.rootPath::haxe-nav.css" rel="stylesheet" />
 	<script type="text/javascript">var dox = {
 		rootPath: "::api.config.rootPath::",

--- a/themes/default/templates/main.mtt
+++ b/themes/default/templates/main.mtt
@@ -34,53 +34,9 @@
 	<meta name="description" ::cond type.doc!=null && description.length>0:: content="::description::"/>
 </head>
 <body>
-	<nav class="section nav dark">
-	<div class="navbar navbar-fixed-top navbar-inverse">
-		<div class="navbar-inner">
-			<button class="btn btn-navbar" data-target=".nav-collapse" data-toggle="collapse" type="button"><span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span></button> <a class="brand haxe-logo" href="http://haxe.org/"><img alt="Haxe" height="21" onerror="this.src='http://haxe.org/img/haxe-logo-horizontal-on-dark.png'" src="http://haxe.org/img/haxe-logo-horizontal-on-dark.svg" width="107" /></a>
-			
-			<a class="brand sub lib" href="/">API</a>
 
-			<div class="nav-collapse collapse">
-				<ul class="nav">
-					<!-- required submenu  on every subsite, put class="active" on   -->
-					<li class="dropdown">
-						<a class="dropdown-toggle" data-toggle="dropdown" href="/documentation/">Learn Haxe <b class="caret"></b></a>
-						<ul class="dropdown-menu">
-							<li><a href="http://haxe.org/documentation/">Introduction</a></li>
-							<li class="divider"></li>
-							<li><a href="http://haxe.org/manual/">Manual</a></li>
-							<li class="active"><a href="http://api.haxe.org">API Documentation</a></li>
-							<li class="divider"></li>
-							<li><a href="http://try.haxe.org">Try Haxe</a></li>
-							<li><a href="http://lib.haxe.org">Haxelib</a></li>
-							<li><a href="http://code.haxe.org">Code Cookbook</a></li>
-						</ul>
-					</li>
-					<li class=" dropdown">
-						<a class="dropdown-toggle" data-toggle="dropdown" href="#">Connect <b class="caret"></b></a>
-						<ul class="dropdown-menu">
-							<li><a href="https://github.com/HaxeFoundation"><i class="fa fa-github"></i> Github</a></li>
-							<li><a href="https://github.com/HaxeFoundation/haxe/issues"><i class="fa fa-github"></i> Bug reports</a></li>
-							<li><a href="http://stackoverflow.com/questions/tagged/haxe"><i class="fa fa-stack-exchange"></i> Stack Overflow</a></li>
-							<li><a href="http://groups.google.com/group/haxelang?hl=en"><i class="fa fa-envelope-o"></i> Google Groups</a></li>
-							<li><a href="http://webchat.freenode.net/?channels=haxe"><i class="fa fa-comments-o"></i> IRC</a></li>
-							<li><a href="http://haxe.org/blog"><i class="fa fa-rss"></i> Blog</a></li>
-							<li class="divider"></li>
-							<li><a href="https://plus.google.com/communities/103302587329918132234"><i class="fa fa-google-plus"></i> Google+</a></li>
-							<li><a href="https://www.facebook.com/haxe.org/"><i class="fa fa-facebook"></i> Facebook</a></li>
-							<li><a href="https://twitter.com/search?q=%23haxe"><i class="fa fa-twitter"></i> #haxe</a></li>
-							<li><a href="https://twitter.com/haxelang"><i class="fa fa-twitter"></i> @haxelang</a></li>
-							<li><a href="https://twitter.com/haxe_org"><i class="fa fa-twitter"></i> @haxe_org</a></li>
-							<li class="divider"></li>
-							<li><a href="http://haxe.org/foundation/contact.html">Contact</a></li>
-						</ul>
-					</li>
-				</ul>
-			</div>
-		</div>
-	</div>
-</nav>
+::use "header.mtt"::::end::
+
 <div class="container main-content">
 	<div class="row-fluid">
 		<div class="span3">

--- a/themes/default/templates/main.mtt
+++ b/themes/default/templates/main.mtt
@@ -6,9 +6,9 @@
 	<link href="::api.config.rootPath::bootstrap/css/bootstrap-responsive.min.css" rel="stylesheet" />
 	<link href="::api.config.rootPath::bootstrap/css/bootstrap-select.min.css" rel="stylesheet" />
 	
-	<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700,700italic,400italic' rel='stylesheet' type='text/css'/>
-	<link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,600,600italic,400' rel='stylesheet' type='text/css'/>
-	<link href='http://netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css' rel='stylesheet' type='text/css' />
+	<link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700,700italic,400italic' rel='stylesheet' type='text/css'/>
+	<link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,600,600italic,400' rel='stylesheet' type='text/css'/>
+	<link href='https://netdna.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.css' rel='stylesheet' type='text/css' />
 
 	<script src="::api.config.rootPath::jquery-1.9.1.min.js"></script>
 	<script src="::api.config.rootPath::bootstrap/js/bootstrap.min.js"></script>

--- a/themes/default/templates/main.mtt
+++ b/themes/default/templates/main.mtt
@@ -64,17 +64,7 @@
 	</div>
 </div>
 
-<footer class="section dark site-footer">
-	<div class="container">
-		<div class="copyright">
-			<p ::cond api.isDefined("version")::>This documentation is generated for version ::api.getValue('version')::</p>
-			<p>&copy;2015&nbsp;
-			<a href="http://haxe.org/foundation/" title="Haxe Foundation Website" class="hf-link">Haxe Foundation</a> |&nbsp;
-			<a href="https://github.com/HaxeFoundation/haxe" title="Haxe on Github">Contribute to Haxe</a>
-			</p>
-		</div>
-	</div>
-</footer>
+::use "footer.mtt"::::end::
 
 <script src="https://google-code-prettify.googlecode.com/svn/loader/run_prettify.js"></script>
 </body>

--- a/themes/default/templates/nav.mtt
+++ b/themes/default/templates/nav.mtt
@@ -10,7 +10,7 @@
 		<li ::cond name.charAt(0) != "_"::
 			::attr class "expando " +if (depth == 0 && api.isPlatform(name)) "platform platform-" + name else if (depth == 0) "package-" + name else "" ::>
 			<a class="nav-header" href="#" onclick="return toggleCollapsed(this)">
-		<i class="fa fa-arrow-circle-o-right"></i>
+		<i class="fa ::api.config.defines.get("collapsedClass")::"></i>
 				::api.getTreeName(tree)::
 			</a>
 			<ul class="nav nav-list">

--- a/themes/default/templates/package.mtt
+++ b/themes/default/templates/package.mtt
@@ -1,18 +1,7 @@
 ::use 'main.mtt'::
 
 ::if full == ""::
-	<h1>Haxe API documentation <small ::cond api.isDefined("version")::>version ::api.getValue('version')::</small></h1>
-	<p>Haxe is an open source toolkit based on a modern, high level, strictly typed programming language, a cross-compiler, a complete cross-platform standard library and ways to access each platform's native capabilities.</p> 
-	<h3>Getting Started With Haxe</h3>
-	<ul>
-		<li>Take a look at our <a href="http://haxe.org/documentation/introduction/">introduction</a></li>
-		<li>Read through the <a href="http://haxe.org/manual/">Haxe Manual</a></li>
-		<li>Look at these <a href="http://haxe.org/use-cases/">use cases for Haxe</a></li>
-		<li>Find and install <a href="http://lib.haxe.org/t/all/">popular Haxe libraries</a></li>
-		<li>Learn by example with the <a href="http://code.haxe.org">Haxe Code Cookbook</a></li>
-	</ul>
-	<hr/>
-	<h3>Top Level</h3>
+	::use "start.mtt"::::end::
 ::elseif full.split(".").length==1::
 	<h1>Haxe/::full:: API documentation</h1>
 	<p>To get started with the Haxe ::full:: target:</p>

--- a/themes/default/templates/start.mtt
+++ b/themes/default/templates/start.mtt
@@ -1,0 +1,12 @@
+<h1>Haxe API documentation <small ::cond api.isDefined("version")::>version ::api.getValue('version')::</small></h1>
+<p>Haxe is an open source toolkit based on a modern, high level, strictly typed programming language, a cross-compiler, a complete cross-platform standard library and ways to access each platform's native capabilities.</p> 
+<h3>Getting Started With Haxe</h3>
+<ul>
+    <li>Take a look at our <a href="http://haxe.org/documentation/introduction/">introduction</a></li>
+    <li>Read through the <a href="http://haxe.org/manual/">Haxe Manual</a></li>
+    <li>Look at these <a href="http://haxe.org/use-cases/">use cases for Haxe</a></li>
+    <li>Find and install <a href="http://lib.haxe.org/t/all/">popular Haxe libraries</a></li>
+    <li>Learn by example with the <a href="http://code.haxe.org">Haxe Code Cookbook</a></li>
+</ul>
+<hr/>
+<h3>Top Level</h3>


### PR DESCRIPTION
The default theme is pretty great and has basically everything most users would probably want. However, its not easy to just modify certain parts of it (it seems the workflow is to copy the whole thing and edit it), this PR splits things out a little meaning you can just change the parts you want to but still getting the benefits of updates to the parent default theme. 