### PR TITLE
Haxe Theme: fix anchor links being hidden behind the header

### DIFF
--- a/themes/default/resources/extra-styles.css
+++ b/themes/default/resources/extra-styles.css
@@ -1,0 +1,1 @@
+/** to be overridden in sub-themes */

--- a/themes/default/templates/class_field.mtt
+++ b/themes/default/templates/class_field.mtt
@@ -9,10 +9,10 @@
 
 	<a ::attr name field.name::></a>
 	<h3>
-		<p>$$printFieldSignature(::field::,::isStatic::,::type::)</p>
+		<p class="anchor">$$printFieldSignature(::field::,::isStatic::,::type::)</p>
 		::if field.overloads != null::
 			::foreach field field.overloads::
-				<p>$$printFieldSignature(::field::,::isStatic::,::type::)</p>
+				<p class="anchor">$$printFieldSignature(::field::,::isStatic::,::type::)</p>
 			::end::
 		::end::
 	</h3>

--- a/themes/default/templates/header.mtt
+++ b/themes/default/templates/header.mtt
@@ -12,6 +12,7 @@
 	<script src="::api.config.rootPath::bootstrap/js/bootstrap.min.js"></script>
 	<script src="::api.config.rootPath::bootstrap/js/bootstrap-select.min.js"></script>
 	<link href="::api.config.rootPath::styles.css" rel="stylesheet" />
+	<link href="::api.config.rootPath::extra-styles.css" rel="stylesheet" />
 	<link href="::api.config.rootPath::haxe-nav.css" rel="stylesheet" />
 	<script type="text/javascript">var dox = {
 		rootPath: "::api.config.rootPath::",

--- a/themes/haxe_api/resources/extra-styles.css
+++ b/themes/haxe_api/resources/extra-styles.css
@@ -1,0 +1,4 @@
+.anchor {
+  padding-top: 60px;
+  margin-top: -60px;
+}


### PR DESCRIPTION
If you link to a specific field on api.haxe.org, you'll notice you don't actually see the field's name:

http://api.haxe.org/StringTools.html#winMetaCharacters

![](http://i.imgur.com/ehNtPuf.png)

This is because the name gets hidden behind the fixed header.

This PR adds an extra offset to anchors to fix that issue:

- Added extra-styles.css to allow adding styles in sub-themes without copy-pasing the entire styles.css.
- The anchor class was added to class_field.mtt directly, even though it's not used for the default theme, to avoid duplicating the file.

