### PR TITLE
Properly check for the HAXELIB_RUN env var

### DIFF
--- a/src/dox/Dox.hx
+++ b/src/dox/Dox.hx
@@ -11,10 +11,9 @@ class Dox {
 
 		// check if we're running from haxelib (last arg is original working dir)
 		var last = args[args.length - 1];
-		if (last != null) {
+		if (last != null && Sys.getEnv("HAXELIB_RUN") == "1") {
 			var path = new Path(last).toString();
-			if (FileSystem.exists(path) && FileSystem.isDirectory(path)
-				&& (args.length < 2 || args[args.length - 2].charCodeAt(0) != "-".code)) {
+			if (FileSystem.exists(path) && FileSystem.isDirectory(path)) {
 				args.pop();
 				Sys.setCwd(path);
 			}


### PR DESCRIPTION
The current charCodeAt() hackery leads to flag-arguments like --no-markdown causing an exception (noticed this while trying to add a --help):

```
>haxelib run dox --no-markdown
Called from ? line 1
Called from dox/Dox.hx line 119
Called from hxargs/Args.hx line 73
Uncaught exception - Unknown command: C:\HaxeToolkit\haxe\lib\dox\git/
```

It's much cleaner to check the HAXELIB_RUN env var that Haxelib defines for exactly this purpose.