### PR TITLE
Fix a 1px gap under the default theme's footer

### DIFF
--- a/themes/default/resources/styles.css
+++ b/themes/default/resources/styles.css
@@ -54,6 +54,9 @@ footer{
 	margin-top:40px;
 	font-size:14px;
 }
+.section.site-footer {
+	border-bottom: 0px;
+}
 .copyright {
 	padding: 6px;
 	overflow: hidden;


### PR DESCRIPTION
`.section` has a 1px `border-bottom`, which also happens to be applied to the footer. It's not really noticable with the grey footer in the default theme, but you can see it in the Haxe theme on http://api.haxe.org/.