### PR TITLE
Fix dead links to top-level package

### DIFF
--- a/src/dox/Api.hx
+++ b/src/dox/Api.hx
@@ -170,6 +170,9 @@ class Api {
 		Turns a package-path into a slash-path and appends "/index.html".
 	**/
 	public function packageToUrl(full:String):String {
+		if(full == config.toplevelPackage) {
+			return config.rootPath + "index.html";
+		}
 		return config.rootPath + full.split(".").join("/") + "/index.html";
 		
 	}

--- a/themes/default/templates/package.mtt
+++ b/themes/default/templates/package.mtt
@@ -7,7 +7,7 @@
 		<tr ::cond full != ""::>
 			<th width="200">
 				<i class="fa fa-folder-o"></i>
-				<a href="../index.html" title="::full.split(".").slice(0,-1).join(".")::">..</a>
+				<a href="::api.packageToUrl(full.split(".").slice(0,-1).join("."))::" title="::full.split(".").slice(0,-1).join(".")::">..</a>
 			</th>
 			<td></td>
 		</tr>


### PR DESCRIPTION
For example, when executing dox with `--top-level-package com.example.api` the URL that is used every where to reference back to the top-level package looks like `https://server/apidocs/com/example/api/index.html`. Dox however generates the index.html at `https://server/apidocs/index.html`, thus all links pointing to the top-level package result in 404.