### PR TITLE
Adds a template for 404 pages

### DIFF
--- a/src/dox/Dox.hx
+++ b/src/dox/Dox.hx
@@ -173,6 +173,9 @@ class Dox {
 		Sys.println("Generating navigation");
 		gen.generateNavigation(root);
 
+		Sys.println("Generating 404 page");
+		gen.generateErrorPage(root);
+
 		Sys.println('Generating to ${cfg.outputPath}');
 		gen.generate(root);
 

--- a/src/dox/Generator.hx
+++ b/src/dox/Generator.hx
@@ -15,6 +15,7 @@ class Generator {
 	var tplEnum:templo.Template;
 	var tplTypedef:templo.Template;
 	var tplAbstract:templo.Template;
+	var tplError:templo.Template;
 
 	public function new(api:Api, writer:Writer) {
 		this.api = api;
@@ -26,6 +27,7 @@ class Generator {
 		tplEnum = config.loadTemplate("enum.mtt");
 		tplTypedef = config.loadTemplate("typedef.mtt");
 		tplAbstract = config.loadTemplate("abstract.mtt");
+		tplError = config.loadTemplate("404.mtt");
 	}
 
 	public function generate(root:TypeRoot) {
@@ -42,6 +44,23 @@ class Generator {
 			}
 		});
 		writer.saveContent("nav.js", ~/[\r\n\t]/g.replace(s, ""));
+	}
+
+	public function generateErrorPage(root:TypeRoot) {
+		var full = 'File not found';
+		var name = 'File not found';
+		api.config.setRootPath('');
+		api.currentPageName = full == "" ? name : full;
+		var s = tplError.execute({
+			api: api,
+			name: name,
+			full: full,
+			root: switch (root) {
+				case [TPackage(_, '', subs)]: subs;
+				default: throw "root should be [top level package]";
+			}
+		});
+		writer.saveContent("404.html", ~/[\r\n\t]/g.replace(s, ""));
 	}
 
 	@:access(dox.Api.sanitizePath)

--- a/themes/default/resources/index.js
+++ b/themes/default/resources/index.js
@@ -231,3 +231,21 @@ function searchMatch(text, queryParts) {
 	}
 	return scoreSum;
 }
+
+function errorSearch() {
+	var errorURL = "";
+	if(!!window.location.pathname) {
+		errorURL = window.location.pathname;
+	}else if(!!window.location.href) {
+		errorURL = window.location.href;
+	}
+	if(!!errorURL) {
+		var searchTerm = errorURL.split("/").pop();
+		if(searchTerm.indexOf(".html") > -1) { searchTerm = searchTerm.split(".html").join(""); }
+		if(!!searchTerm) {
+			// update filter with search term
+			$("#search").val(searchTerm);
+			searchQuery(searchTerm);
+		}
+	}
+}

--- a/themes/default/templates/404.mtt
+++ b/themes/default/templates/404.mtt
@@ -1,0 +1,12 @@
+::use 'main.mtt'::
+
+<script type="text/javascript">
+	$(document).ready(errorSearch);
+</script>
+
+<h1><small>404</small> Page not found</h1>
+
+<p>Page not found, sorry.</p>
+
+::end::
+


### PR DESCRIPTION
Adds a template for 404.html pages

Default behaviour is trying to filter for the searched string. So if the url ends with `string.html`, it will filter for `string` in the left navbar.