### PR TITLE
file association for .mtt -> html

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,8 @@
 	"[javascript]": {
 		"editor.formatOnSave": true,
 		"editor.defaultFormatter": "vscode.typescript-language-features"
-	}
+	},
+	"files.associations": {
+		"*.mtt": "html"
+  	}
 }


### PR DESCRIPTION
Just a simple config option, this tells things like Github and VSCode that we can perform syntax highlighting on `.mtt` in the style of `.html` files, since they are mostly html

Of course doesn't cover any templating related highlighting. Unless there's some VSCode extension I'm unaware of!