### PR TITLE
replace `nekotools server `with `npx http-server` for local development

### DIFF
--- a/Make.hx
+++ b/Make.hx
@@ -15,8 +15,7 @@ function main() {
 				Sys.command("npx lix run dox -o bin/pages -i bin/xml --include dox -D source-path https://github.com/HaxeFoundation/dox/tree/master/test");
 
 			case "server":
-				Sys.setCwd("bin/pages");
-				Sys.command("nekotools server");
+				Sys.command("npx http-server bin/pages -c-1");
 
 			case "package":
 				Sys.command("7z a -i!run.n -i!run.js -i!resources -i!themes -i!src -i!haxelib.json -i!README.md -i!LICENSE.md -i!CHANGELOG.md bin/haxelib.zip");


### PR DESCRIPTION
dox already assumes you have nodejs of some sort setup (requires lix), so this PR changes the `nekotools server` command that loads up the webserver for development purposes, and instead uses `http-server` (which is what `lime` uses, albeit as an included binary rather than npx)

Ideally it can be a more haxe solution ([`snake-server`](https://github.com/BowlerHatLLC/snake-server) would be a good candidate, but it wasn't playing too nicely with lix for me...)

This PR should allow a bit easier development, as well as less reliance on neko